### PR TITLE
Make sure scripts are loaded in the order they've been provided.

### DIFF
--- a/src/View/Helper/HeadScript.php
+++ b/src/View/Helper/HeadScript.php
@@ -154,6 +154,7 @@ class HeadScript extends \Zend\View\Helper\HeadScript
             $scripts[] = $this->itemToString($item, $indent, $escapeStart, $escapeEnd);
         }
 
-        return $scripts;
+        // Make sure the scripts are in the correct order.
+        return array_reverse($scripts, true);
     }
 }


### PR DESCRIPTION
Scripts must be loaded in the correct order if they depend on each other.